### PR TITLE
Custom foreground+background colours

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ import (
 var w = flag.Int("w", 25, "Duration of a working session")
 var s = flag.Int("s", 5, "Duration of a short break")
 var l = flag.Int("l", 15, "Duration of a long break")
-var fg = flag.String("fg", "", "Color of font to display")
 var p = flag.String("p", "wswswl", "Pattern to  follow (for example wswswl)")
 var e = flag.String("e", "", "The command to execute when a session is done")
 var m = flag.String("m", "dark", "Select the color mode (light or dark)")
 var d = flag.Bool("debug", false, "Debug option for development purpose")
+var fg = flag.String("fg", "", "Single or comma separated list of color names for font")
 
 var wg sync.WaitGroup
 
@@ -37,6 +37,11 @@ func main() {
 			fmt.Printf("Invalid pattern ''%s', should contain only w,s, or l\n", *p)
 			os.Exit(2)
 		}
+	}
+	// termbox.ColorDefault is never a valid color.
+	if *fg != "" && painter.Colors[*fg] == termbox.ColorDefault {
+		fmt.Printf("Invalid foreground color specified, please state one or a comma separated list of black, blue, cyan, green, magenta, red, white, or yellow\n")
+		os.Exit(2)
 	}
 	currentState = state.NewState(*p, *w, *s, *l)
 	currentPainter = painter.NewPainter(currentState, *m, *d, *fg)

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var p = flag.String("p", "wswswl", "Pattern to  follow (for example wswswl)")
 var e = flag.String("e", "", "The command to execute when a session is done")
 var m = flag.String("m", "dark", "Select the color mode (light or dark)")
 var d = flag.Bool("debug", false, "Debug option for development purpose")
-var fg = flag.String("fg", "", "Single or comma separated list of color names for font")
+var fg = flag.String("fg", "", "Custom color for font")
 
 var wg sync.WaitGroup
 

--- a/main.go
+++ b/main.go
@@ -40,12 +40,8 @@ func main() {
 		}
 	}
 	// termbox.ColorDefault is never a valid color.
-	if *fg != "" && painter.Colors[*fg] == termbox.ColorDefault {
-		fmt.Printf("Invalid foreground color specified, please state one or a comma separated list of black, blue, cyan, green, magenta, red, white, or yellow\n")
-		os.Exit(2)
-	}
-	if *bg != "" && painter.Colors[*bg] == termbox.ColorDefault {
-		fmt.Printf("Invalid background color specified, please state one or a comma separated list of black, blue, cyan, green, magenta, red, white, or yellow\n")
+	if (*fg != "" && painter.Colors[*fg] == termbox.ColorDefault) || (*bg != "" && painter.Colors[*bg] == termbox.ColorDefault) {
+		fmt.Printf("Invalid background color specified, please state one of black, blue, cyan, green, magenta, red, white, or yellow\n")
 		os.Exit(2)
 	}
 	currentState = state.NewState(*p, *w, *s, *l)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 var w = flag.Int("w", 25, "Duration of a working session")
 var s = flag.Int("s", 5, "Duration of a short break")
 var l = flag.Int("l", 15, "Duration of a long break")
+var c = flag.String("c", "white", "Color of font to display")
 var p = flag.String("p", "wswswl", "Pattern to  follow (for example wswswl)")
 var e = flag.String("e", "", "The command to execute when a session is done")
 var m = flag.String("m", "dark", "Select the color mode (light or dark)")
@@ -38,7 +39,7 @@ func main() {
 		}
 	}
 	currentState = state.NewState(*p, *w, *s, *l)
-	currentPainter = painter.NewPainter(currentState, *m, *d)
+	currentPainter = painter.NewPainter(currentState, *m, *d, *c)
 	currentPainter.Init()
 	currentTimer = util.NewTimer(currentState, currentPainter, *e)
 	go handleKeyEvent()

--- a/main.go
+++ b/main.go
@@ -18,7 +18,8 @@ var p = flag.String("p", "wswswl", "Pattern to  follow (for example wswswl)")
 var e = flag.String("e", "", "The command to execute when a session is done")
 var m = flag.String("m", "dark", "Select the color mode (light or dark)")
 var d = flag.Bool("debug", false, "Debug option for development purpose")
-var fg = flag.String("fg", "", "Custom color for font")
+var fg = flag.String("fg", "", "Custom foreground color")
+var bg = flag.String("bg", "", "Custom background color")
 
 var wg sync.WaitGroup
 
@@ -43,8 +44,12 @@ func main() {
 		fmt.Printf("Invalid foreground color specified, please state one or a comma separated list of black, blue, cyan, green, magenta, red, white, or yellow\n")
 		os.Exit(2)
 	}
+	if *bg != "" && painter.Colors[*bg] == termbox.ColorDefault {
+		fmt.Printf("Invalid background color specified, please state one or a comma separated list of black, blue, cyan, green, magenta, red, white, or yellow\n")
+		os.Exit(2)
+	}
 	currentState = state.NewState(*p, *w, *s, *l)
-	currentPainter = painter.NewPainter(currentState, *m, *d, *fg)
+	currentPainter = painter.NewPainter(currentState, *m, *d, *fg, *bg)
 	currentPainter.Init()
 	currentTimer = util.NewTimer(currentState, currentPainter, *e)
 	go handleKeyEvent()

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 var w = flag.Int("w", 25, "Duration of a working session")
 var s = flag.Int("s", 5, "Duration of a short break")
 var l = flag.Int("l", 15, "Duration of a long break")
-var c = flag.String("c", "white", "Color of font to display")
+var fg = flag.String("fg", "", "Color of font to display")
 var p = flag.String("p", "wswswl", "Pattern to  follow (for example wswswl)")
 var e = flag.String("e", "", "The command to execute when a session is done")
 var m = flag.String("m", "dark", "Select the color mode (light or dark)")
@@ -39,7 +39,7 @@ func main() {
 		}
 	}
 	currentState = state.NewState(*p, *w, *s, *l)
-	currentPainter = painter.NewPainter(currentState, *m, *d, *c)
+	currentPainter = painter.NewPainter(currentState, *m, *d, *fg)
 	currentPainter.Init()
 	currentTimer = util.NewTimer(currentState, currentPainter, *e)
 	go handleKeyEvent()

--- a/painter/painter.go
+++ b/painter/painter.go
@@ -52,11 +52,11 @@ func NewPainter(state *state.State, m string, debug bool, fg string, bg string) 
 	timerFg = textFg
 
 	if fg != "" {
-		timerFg = Colors[fg]
+		timerFg = Colors[strings.ToLower(fg)]
 		textFg = timerFg
 	}
 	if bg != "" {
-		timerBg = Colors[bg]
+		timerBg = Colors[strings.ToLower(bg)]
 	}
 
 	mode = ColorMode{

--- a/painter/painter.go
+++ b/painter/painter.go
@@ -35,28 +35,32 @@ var Colors = map[string]termbox.Attribute{
 }
 
 // NewPainter create a new painter based on a state, the color mode and the debug mode
-func NewPainter(state *state.State, m string, debug bool, fg string) *Painter {
+func NewPainter(state *state.State, m string, debug bool, fg string, bg string) *Painter {
 	var mode ColorMode
-	var bg termbox.Attribute
+	var timerBg termbox.Attribute
 	var timerFg termbox.Attribute
 	var textFg termbox.Attribute
 
 	if m == "light" {
-		bg = Colors["white"]
-		textFg = Colors["black"]
+		timerBg = Colors["white"]
+		textFg = Colors["red"]
 	} else {
-		bg = Colors["black"]
-		textFg = Colors["white"]
+		timerBg = Colors["black"]
+		textFg = Colors["red"]
 	}
+
 	timerFg = textFg
 
 	if fg != "" {
 		timerFg = Colors[fg]
 		textFg = timerFg
 	}
+	if bg != "" {
+		timerBg = Colors[bg]
+	}
 
 	mode = ColorMode{
-		Bg:      bg,
+		Bg:      timerBg,
 		TimerFG: timerFg,
 		TextFG:  textFg,
 	}

--- a/painter/painter.go
+++ b/painter/painter.go
@@ -23,6 +23,17 @@ type Painter struct {
 	debug        bool
 }
 
+var Colors = map[string]termbox.Attribute{
+	"black":   termbox.ColorBlack,
+	"blue":    termbox.ColorBlue,
+	"cyan":    termbox.ColorCyan,
+	"green":   termbox.ColorGreen,
+	"magenta": termbox.ColorMagenta,
+	"red":     termbox.ColorRed,
+	"white":   termbox.ColorWhite,
+	"yellow":  termbox.ColorYellow,
+}
+
 // NewPainter create a new painter based on a state, the color mode and the debug mode
 func NewPainter(state *state.State, m string, debug bool, fg string) *Painter {
 	var mode ColorMode
@@ -30,34 +41,17 @@ func NewPainter(state *state.State, m string, debug bool, fg string) *Painter {
 	var timerFg termbox.Attribute
 	var textFg termbox.Attribute
 
-	colors := map[string]termbox.Attribute{
-		"black":   termbox.ColorBlack,
-		"blue":    termbox.ColorBlue,
-		"cyan":    termbox.ColorCyan,
-		"green":   termbox.ColorGreen,
-		"magenta": termbox.ColorMagenta,
-		"red":     termbox.ColorRed,
-		"white":   termbox.ColorWhite,
-		"yellow":  termbox.ColorYellow,
-	}
-
 	if m == "light" {
-		bg = colors["white"]
-		textFg = colors["black"]
+		bg = Colors["white"]
+		textFg = Colors["black"]
 	} else {
-		bg = colors["black"]
-		textFg = colors["white"]
+		bg = Colors["black"]
+		textFg = Colors["white"]
 	}
 	timerFg = textFg
 
-	// TODO
-	// See https://github.com/nsf/termbox-go/blob/8c5e0793e04afcda7fe23d0751791e7321df4265/api_common.go#L133
-	// Basically, it'd be nice if we could allow something like:
-	// gone -fg blue,green # produces cyan
-	// As well as customing background with -bg
-	// instead of 'light' and 'dark' modes
 	if fg != "" {
-		timerFg = colors[fg]
+		timerFg = Colors[fg]
 		textFg = timerFg
 	}
 

--- a/painter/painter.go
+++ b/painter/painter.go
@@ -24,20 +24,40 @@ type Painter struct {
 }
 
 // NewPainter create a new painter based on a state, the color mode and the debug mode
-func NewPainter(state *state.State, m string, debug bool) *Painter {
+func NewPainter(state *state.State, m string, debug bool, fontColor string) *Painter {
 	var mode ColorMode
+	var bg termbox.Attribute
+	var timerFg termbox.Attribute
+
 	if m == "light" {
-		mode = ColorMode{
-			Bg:      termbox.ColorWhite,
-			TimerFG: termbox.ColorRed,
-			TextFG:  termbox.ColorBlack,
-		}
+		bg = termbox.ColorWhite
 	} else {
-		mode = ColorMode{
-			Bg:      termbox.ColorBlack,
-			TimerFG: termbox.ColorRed,
-			TextFG:  termbox.ColorWhite,
-		}
+		bg = termbox.ColorBlack
+	}
+
+	switch strings.ToLower(fontColor) {
+	case "black":
+		timerFg = termbox.ColorBlack
+	case "blue":
+		timerFg = termbox.ColorBlue
+	case "cyan":
+		timerFg = termbox.ColorCyan
+	case "green":
+		timerFg = termbox.ColorGreen
+	case "magenta":
+		timerFg = termbox.ColorMagenta
+	case "red":
+		timerFg = termbox.ColorRed
+	case "white":
+		timerFg = termbox.ColorWhite
+	case "yellow":
+		timerFg = termbox.ColorYellow
+	}
+
+	mode = ColorMode{
+		Bg:      bg,
+		TimerFG: timerFg,
+		TextFG:  termbox.ColorWhite,
 	}
 	return &Painter{
 		state:        state,

--- a/painter/painter.go
+++ b/painter/painter.go
@@ -24,40 +24,47 @@ type Painter struct {
 }
 
 // NewPainter create a new painter based on a state, the color mode and the debug mode
-func NewPainter(state *state.State, m string, debug bool, fontColor string) *Painter {
+func NewPainter(state *state.State, m string, debug bool, fg string) *Painter {
 	var mode ColorMode
 	var bg termbox.Attribute
 	var timerFg termbox.Attribute
+	var textFg termbox.Attribute
 
-	if m == "light" {
-		bg = termbox.ColorWhite
-	} else {
-		bg = termbox.ColorBlack
+	colors := map[string]termbox.Attribute{
+		"black":   termbox.ColorBlack,
+		"blue":    termbox.ColorBlue,
+		"cyan":    termbox.ColorCyan,
+		"green":   termbox.ColorGreen,
+		"magenta": termbox.ColorMagenta,
+		"red":     termbox.ColorRed,
+		"white":   termbox.ColorWhite,
+		"yellow":  termbox.ColorYellow,
 	}
 
-	switch strings.ToLower(fontColor) {
-	case "black":
-		timerFg = termbox.ColorBlack
-	case "blue":
-		timerFg = termbox.ColorBlue
-	case "cyan":
-		timerFg = termbox.ColorCyan
-	case "green":
-		timerFg = termbox.ColorGreen
-	case "magenta":
-		timerFg = termbox.ColorMagenta
-	case "red":
-		timerFg = termbox.ColorRed
-	case "white":
-		timerFg = termbox.ColorWhite
-	case "yellow":
-		timerFg = termbox.ColorYellow
+	if m == "light" {
+		bg = colors["white"]
+		textFg = colors["black"]
+	} else {
+		bg = colors["black"]
+		textFg = colors["white"]
+	}
+	timerFg = textFg
+
+	// TODO
+	// See https://github.com/nsf/termbox-go/blob/8c5e0793e04afcda7fe23d0751791e7321df4265/api_common.go#L133
+	// Basically, it'd be nice if we could allow something like:
+	// gone -fg blue,green # produces cyan
+	// As well as customing background with -bg
+	// instead of 'light' and 'dark' modes
+	if fg != "" {
+		timerFg = colors[fg]
+		textFg = timerFg
 	}
 
 	mode = ColorMode{
 		Bg:      bg,
 		TimerFG: timerFg,
-		TextFG:  termbox.ColorWhite,
+		TextFG:  textFg,
 	}
 	return &Painter{
 		state:        state,


### PR DESCRIPTION
Thanks for the program!

This adds support to customise the foreground and background colour based on a flag (`fg` and `bg`, respectively) based on the options available from `termbox-go`. There is the ability to mix these into certain combinations by ORing the `Attribute`s, but I'm not really sure that's a nice layout for the general user of `gone` (I tried in a different branch and it was clunky). 

Usage is:

`gone -fg black -bg white` 