### PR TITLE
Add desktop notifications

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -99,7 +99,22 @@ func (s *State) Message() string {
 	return "paused"
 }
 
-// formatDuration format a duration to 12:34
+// StatusMessage returns a message describing the state of a session.
+func (s *State) StatusMessage() string {
+	msgs := map[byte]string{
+		'w': "working session",
+		's': "short break",
+		'l': "long break",
+	}
+
+	if !s.IsEnded() {
+		return fmt.Sprintf("A %s is in progress", msgs[s.pattern[s.currentIdx]])
+	}
+
+	return fmt.Sprintf("Your %s has ended, time for a %s.", msgs[s.pattern[s.currentIdx]], msgs[s.pattern[s.currentIdx+1]])
+}
+
+// Duration format a duration to 12:34 (mm:ss).
 func (s *State) Duration() string {
 	seconds := s.duration % 60
 	minutes := s.duration / 60

--- a/state/state.go
+++ b/state/state.go
@@ -107,11 +107,24 @@ func (s *State) StatusMessage() string {
 		'l': "long break",
 	}
 
-	if !s.IsEnded() {
-		return fmt.Sprintf("A %s is in progress", msgs[s.pattern[s.currentIdx]])
+	if len(s.pattern) <= s.currentIdx {
+		return "Gone encountered an unknown state"
 	}
 
-	return fmt.Sprintf("Your %s has ended, time for a %s.", msgs[s.pattern[s.currentIdx]], msgs[s.pattern[s.currentIdx+1]])
+	currentState := msgs[s.pattern[s.currentIdx]]
+
+	if !s.IsEnded() {
+		return fmt.Sprintf("A %s is in progress", currentState)
+	}
+
+	nextState := msgs[s.pattern[0]] // Fallback for error handling.
+
+	// Set next pattern unless it overflows.
+	if s.currentIdx != len(s.pattern)-1 {
+		nextState = msgs[s.pattern[s.currentIdx+1]]
+	}
+
+	return fmt.Sprintf("Your %s has ended, time for a %s.", currentState, nextState)
 }
 
 // Duration format a duration to 12:34 (mm:ss).

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,0 +1,83 @@
+package state
+
+import "testing"
+
+func TestStatusMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		got  *State
+		want string
+	}{
+		{
+			name: "default from main",
+			got:  NewState("wswswl", 25, 5, 15),
+			want: "A working session is in progress",
+		},
+		{
+			name: "one working state",
+			got:  NewState("w", 25, 5, 15),
+			want: "A working session is in progress",
+		},
+		{
+			name: "one break state",
+			got:  NewState("s", 25, 5, 15),
+			want: "A short break is in progress",
+		},
+		{
+			name: "next state",
+			got: func() *State {
+				s := NewState("wswl", 25, 5, 15)
+				s.currentIdx++
+				return s
+			}(),
+			want: "A short break is in progress",
+		},
+		{
+			name: "invalid state",
+			got: func() *State {
+				s := NewState("s", 25, 5, 15)
+				s.currentIdx++
+				return s
+			}(),
+			want: "Gone encountered an unknown state",
+		},
+		{
+			name: "ended state",
+			got: func() *State {
+				s := NewState("wswl", 25, 5, 15)
+				s.duration = 0
+				return s
+			}(),
+			want: "Your working session has ended, time for a short break.",
+		},
+		{
+			name: "ended state second index",
+			got: func() *State {
+				s := NewState("wswl", 25, 5, 15)
+				s.currentIdx++
+				s.duration = 0
+				return s
+			}(),
+			want: "Your short break has ended, time for a working session.",
+		},
+		{
+			name: "ended state circular state",
+			got: func() *State {
+				s := NewState("wswl", 25, 5, 15)
+				s.currentIdx = 3
+				s.duration = 0
+				return s
+			}(),
+			want: "Your long break has ended, time for a working session.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			got := test.got.StatusMessage()
+			if got != test.want {
+				t.Errorf("want status = %q, got %q", test.want, got)
+			}
+		})
+	}
+}

--- a/util/notifier.go
+++ b/util/notifier.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"github.com/0xAX/notificator"
+)
+
+// Notifier is an interface to send notifications.
+type Notifier interface {
+	Notify(title string, text string) error
+}
+
+// desktopNotifier implements the Notifier interface.
+type desktopNotifier struct {
+	*notificator.Notificator
+}
+
+// NewDesktopNotifier creates a new notifier.
+func NewDesktopNotifier() Notifier {
+	return &desktopNotifier{
+		notificator.New(notificator.Options{
+			DefaultIcon: "icon/default.png",
+			AppName:     "gone (pomodoro)",
+		}),
+	}
+}
+
+// Notify sends a desktop notification.
+func (d *desktopNotifier) Notify(title, text string) error {
+	return d.Push(title, text, "", notificator.UR_NORMAL)
+}
+
+// nullNotifier is a notifier that doesn't do anything.
+type nullNotifier struct{}
+
+// NewNullNotifier returns a notifier that is silent.
+func NewNullNotifier() Notifier {
+	return &nullNotifier{}
+}
+
+// Notify does not do anything.
+func (n *nullNotifier) Notify(title, text string) error {
+	return nil
+}

--- a/util/timer.go
+++ b/util/timer.go
@@ -2,32 +2,35 @@ package util
 
 import (
 	"fmt"
-	"github.com/guillaumebreton/gone/painter"
-	"github.com/guillaumebreton/gone/state"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/guillaumebreton/gone/painter"
+	"github.com/guillaumebreton/gone/state"
 )
 
 // Timer count time and update the state accordingly.
 type Timer struct {
-	state   *state.State
-	command string
-	ticker  *time.Ticker
-	painter *painter.Painter
+	state    *state.State
+	command  string
+	ticker   *time.Ticker
+	painter  *painter.Painter
+	notifier Notifier
 }
 
 // NewTimer create a new timer using a state, a command to execute
-// and a painter to draw the screnn
-func NewTimer(s *state.State, p *painter.Painter, c string) *Timer {
+// and a painter to draw the screen.
+func NewTimer(s *state.State, p *painter.Painter, c string, n Notifier) *Timer {
 	return &Timer{
-		state:   s,
-		painter: p,
-		command: c,
+		state:    s,
+		painter:  p,
+		command:  c,
+		notifier: n,
 	}
 }
 
-// run launch a timer and write the counter using the writer
+// Run launch a timer and write the counter using the writer.
 func (t *Timer) Run() {
 	//start a new timer
 	t.ticker = time.NewTicker(250 * time.Millisecond)
@@ -38,13 +41,12 @@ func (t *Timer) Run() {
 			i = 1
 			t.state.Decrease()
 			if t.state.IsEnded() {
+				t.notifier.Notify("Pomodoro", t.state.StatusMessage())
 				break
 			}
-		} else {
-
-			i++
+			continue
 		}
-
+		i++
 	}
 	t.ticker.Stop()
 	if t.command != "" {
@@ -59,7 +61,7 @@ func (t *Timer) Run() {
 	t.painter.Draw()
 }
 
-// Stop the timer
+// Stop the timer.
 func (t *Timer) Stop() {
 	if t.ticker != nil {
 		t.ticker.Stop()

--- a/vendor/github.com/0xAX/notificator/LICENSE
+++ b/vendor/github.com/0xAX/notificator/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, 0xAX
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/0xAX/notificator/README.md
+++ b/vendor/github.com/0xAX/notificator/README.md
@@ -1,0 +1,49 @@
+notificator
+===========================
+
+Desktop notification with Golang for:
+
+  * Windows with `growlnotify`;
+  * Mac OS X with `terminal-notifier` (if installed) or `osascript` (native, 10.9 Mavericks or Up.);
+  * Linux with `notify-send` for Gnome and `kdialog` for Kde.
+
+Usage
+------
+
+```go
+package main
+
+import (
+  "github.com/0xAX/notificator"
+)
+
+var notify *notificator.Notificator
+
+func main() {
+
+  notify = notificator.New(notificator.Options{
+    DefaultIcon: "icon/default.png",
+    AppName:     "My test App",
+  })
+
+  notify.Push("title", "text", "/home/user/icon.png", notificator.UR_CRITICAL)
+}
+```
+
+TODO
+-----
+
+  * Add more options for different notificators.
+
+Сontribution
+------------
+
+  * Fork;
+  * Make changes;
+  * Send pull request;
+  * Thank you.
+
+author
+----------
+
+[@0xAX](https://twitter.com/0xAX)

--- a/vendor/github.com/0xAX/notificator/notification.go
+++ b/vendor/github.com/0xAX/notificator/notification.go
@@ -1,0 +1,166 @@
+package notificator
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type Options struct {
+	DefaultIcon string
+	AppName     string
+}
+
+const (
+	UR_NORMAL   = "normal"
+	UR_CRITICAL = "critical"
+)
+
+type notifier interface {
+	push(title string, text string, iconPath string) *exec.Cmd
+	pushCritical(title string, text string, iconPath string) *exec.Cmd
+}
+
+type Notificator struct {
+	notifier    notifier
+	defaultIcon string
+}
+
+func (n Notificator) Push(title string, text string, iconPath string, urgency string) error {
+	icon := n.defaultIcon
+
+	if iconPath != "" {
+		icon = iconPath
+	}
+
+	if urgency == UR_CRITICAL {
+		return n.notifier.pushCritical(title, text, icon).Run()
+	}
+
+	return n.notifier.push(title, text, icon).Run()
+
+}
+
+type osxNotificator struct {
+	AppName string
+}
+
+func (o osxNotificator) push(title string, text string, iconPath string) *exec.Cmd {
+
+	// Checks if terminal-notifier exists, and is accessible.
+
+	term_notif := CheckTermNotif()
+	os_version_check := CheckMacOSVersion()
+
+	// if terminal-notifier exists, use it.
+	// else, fall back to osascript. (Mavericks and later.)
+
+	if term_notif == true {
+		return exec.Command("terminal-notifier", "-title", o.AppName, "-message", text, "-subtitle", title, "-appIcon", iconPath)
+	} else if os_version_check == true {
+		title = strings.Replace(title, `"`, `\"`,  -1)
+		text = strings.Replace(text, `"`, `\"`,  -1)
+		
+		notification := fmt.Sprintf("display notification \"%s\" with title \"%s\" subtitle \"%s\"", text, o.AppName, title)
+		return exec.Command("osascript", "-e", notification)
+	}
+
+	// finally falls back to growlnotify.
+
+	return exec.Command("growlnotify", "-n", o.AppName, "--image", iconPath, "-m", title)
+}
+
+// Causes the notification to stick around until clicked.
+func (o osxNotificator) pushCritical(title string, text string, iconPath string) *exec.Cmd {
+
+	// same function as above...
+
+	term_notif := CheckTermNotif()
+	os_version_check := CheckMacOSVersion()
+
+	if term_notif == true {
+		// timeout set to 30 seconds, to show the importance of the notification
+		return exec.Command("terminal-notifier", "-title", o.AppName, "-message", text, "-subtitle", title, "-timeout", "30")
+	} else if os_version_check == true {
+		notification := fmt.Sprintf("display notification \"%s\" with title \"%s\" subtitle \"%s\"", text, o.AppName, title)
+		return exec.Command("osascript", "-e", notification)
+	}
+
+	return exec.Command("growlnotify", "-n", o.AppName, "--image", iconPath, "-m", title)
+
+}
+
+type linuxNotificator struct{}
+
+func (l linuxNotificator) push(title string, text string, iconPath string) *exec.Cmd {
+	return exec.Command("notify-send", "-i", iconPath, title, text)
+}
+
+// Causes the notification to stick around until clicked.
+func (l linuxNotificator) pushCritical(title string, text string, iconPath string) *exec.Cmd {
+	return exec.Command("notify-send", "-i", iconPath, title, text, "-u", "critical")
+}
+
+type windowsNotificator struct{}
+
+func (w windowsNotificator) push(title string, text string, iconPath string) *exec.Cmd {
+	return exec.Command("growlnotify", "/i:", iconPath, "/t:", title, text)
+}
+
+// Causes the notification to stick around until clicked.
+func (w windowsNotificator) pushCritical(title string, text string, iconPath string) *exec.Cmd {
+	return exec.Command("notify-send", "-i", iconPath, title, text, "/s", "true", "/p", "2")
+}
+
+func New(o Options) *Notificator {
+
+	var Notifier notifier
+
+	switch runtime.GOOS {
+
+	case "darwin":
+		Notifier = osxNotificator{AppName: o.AppName}
+	case "linux":
+		Notifier = linuxNotificator{}
+	case "windows":
+		Notifier = windowsNotificator{}
+
+	}
+
+	return &Notificator{notifier: Notifier, defaultIcon: o.DefaultIcon}
+}
+
+// Helper function for macOS
+
+func CheckTermNotif() bool {
+	// Checks if terminal-notifier exists, and is accessible.
+	if err := exec.Command("which", "terminal-notifier").Run(); err != nil {
+		return false
+	}
+	// no error, so return true. (terminal-notifier exists)
+	return true
+}
+
+func CheckMacOSVersion() bool {
+	// Checks if the version of macOS is 10.9 or Higher (osascript support for notifications.)
+
+	cmd := exec.Command("sw_vers", "-productVersion")
+	check, _ := cmd.Output()
+
+	version := strings.Split(strings.TrimSpace(string(check)), ".")
+
+	// semantic versioning of macOS
+
+	major, _ := strconv.Atoi(version[0])
+	minor, _ := strconv.Atoi(version[1])
+
+	if major < 10 {
+		return false
+	} else if major == 10 && minor < 9 {
+		return false
+	} else {
+		return true
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "C0AsOR8tLzWrfwWynYx3XsTLFss=",
+			"path": "github.com/0xAX/notificator",
+			"revision": "88d57ee9043ba88d6a62e437fa15dda1ca0d2b59",
+			"revisionTime": "2017-10-22T18:20:52Z"
+		},
+		{
 			"checksumSHA1": "yf185lmVPcvXjLZuPT1s4JzxI18=",
 			"path": "github.com/mattn/go-runewidth",
 			"revision": "737072b4e32b7a5018b4a7125da8d12de90e8045",


### PR DESCRIPTION
This adds desktop notifications for Gone to be able to see when a
session has ended. The change introduces a message that will say for
instance that "Your working session has ended, time for a short break".
A Notifier interface has been added to make sure that the feature can be
extended with custom notifiers.

Desktop notifications is nice to have to be able to get an interruption
when a session is done.

Thanks!